### PR TITLE
Updated Google Collections Dependency (latest)

### DIFF
--- a/atunit-guice/src/main/java/atunit/guice/GuiceContainer.java
+++ b/atunit-guice/src/main/java/atunit/guice/GuiceContainer.java
@@ -20,12 +20,10 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.Map;
-
 import atunit.core.IContainer;
-
+import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
-import com.google.common.collect.Multimaps;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -59,7 +57,7 @@ public class GuiceContainer implements IContainer {
 		protected void configure() {
 
 			// map field values by type
-			Multimap<Type, Field> fieldsByType = Multimaps.newHashMultimap();
+			Multimap<Type, Field> fieldsByType = HashMultimap.create();
 			for (Field field : fields.keySet()) {
 				fieldsByType.put(field.getGenericType(), field);
 			}

--- a/atunit/pom.xml
+++ b/atunit/pom.xml
@@ -19,8 +19,8 @@
 		</dependency>
 
 		<dependency>
-			<groupId>com.google.code.google-collections</groupId>
-			<artifactId>google-collect</artifactId>
+			<groupId>com.google.collections</groupId>
+			<artifactId>google-collections</artifactId>
 		</dependency>
 
 		<!-- test dependencies -->

--- a/atunit/pom.xml
+++ b/atunit/pom.xml
@@ -19,8 +19,8 @@
 		</dependency>
 
 		<dependency>
-			<groupId>com.google.collections</groupId>
-			<artifactId>google-collections</artifactId>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
 		</dependency>
 
 		<!-- test dependencies -->

--- a/atunit/src/main/java/atunit/core/CoreTestFixture.java
+++ b/atunit/src/main/java/atunit/core/CoreTestFixture.java
@@ -6,12 +6,11 @@ import java.util.Map;
 import java.util.Set;
 
 import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
-
 import atunit.spi.exception.InvalidTestException;
 import atunit.spi.model.TestFixture;
 import atunit.spi.plugin.AtUnitPlugin;
 import atunit.spi.plugin.ContainerPlugin;
+import com.google.common.collect.ImmutableSet;
 
 public class CoreTestFixture implements TestFixture {
 	
@@ -46,7 +45,7 @@ public class CoreTestFixture implements TestFixture {
 	}
 
 	public Set<Field> getFields() {
-		return Sets.immutableSet(fields.keySet());
+		return ImmutableSet.copyOf(fields.keySet());
 	}
 
 	public Class<?> getTestClass() {

--- a/atunit/src/main/java/atunit/core/PluginUtils.java
+++ b/atunit/src/main/java/atunit/core/PluginUtils.java
@@ -4,13 +4,13 @@ import java.util.List;
 import java.util.Set;
 
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-
 import atunit.Plugins;
 import atunit.spi.exception.IncompatiblePluginsException;
 import atunit.spi.plugin.AtUnitPlugin;
 import atunit.spi.plugin.ContainerPlugin;
+import com.google.common.collect.ImmutableList;
+import java.util.Arrays;
 
 public class PluginUtils {
 
@@ -47,10 +47,10 @@ public class PluginUtils {
 		Plugins anno = testClass.getAnnotation(Plugins.class);
 		if ( anno != null ) {
 			// whack any duplicates
-			Set<Class<? extends AtUnitPlugin>> plugins = Sets.newLinkedHashSet(anno.value()); 
-			return Lists.immutableList(plugins);
+			Set<Class<? extends AtUnitPlugin>> plugins = Sets.newLinkedHashSet(Arrays.asList(anno.value())); 
+			return ImmutableList.copyOf(plugins);
 		} else {
-			return Lists.immutableList();
+			return ImmutableList.of();
 		}
 		
 	}

--- a/atunit/src/main/java/atunit/core/TestClassUtils.java
+++ b/atunit/src/main/java/atunit/core/TestClassUtils.java
@@ -9,6 +9,7 @@ import atunit.Mock;
 import atunit.Stub;
 import atunit.Unit;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 
 final public class TestClassUtils {
@@ -46,7 +47,7 @@ final public class TestClassUtils {
 				}
 			}
 		}
-		return Sets.immutableSet(fields);
+		return ImmutableSet.copyOf(fields);
 	}
 
 	/**
@@ -103,7 +104,7 @@ final public class TestClassUtils {
 				mocks.add(field);
 			}
 		}
-		return Sets.immutableSet(mocks);
+		return ImmutableSet.copyOf(mocks);
 	}
 
 	/**
@@ -116,7 +117,7 @@ final public class TestClassUtils {
 				stubs.add(field);
 			}
 		}
-		return Sets.immutableSet(stubs);
+		return ImmutableSet.copyOf(stubs);
 	}
 
 }

--- a/atunit/src/main/java/atunit/spi/exception/IncompatiblePluginsException.java
+++ b/atunit/src/main/java/atunit/spi/exception/IncompatiblePluginsException.java
@@ -2,10 +2,8 @@ package atunit.spi.exception;
 
 import java.util.Arrays;
 import java.util.List;
-
-import com.google.common.base.Join;
-
 import atunit.spi.plugin.AtUnitPlugin;
+import com.google.common.base.Joiner;
 
 public class IncompatiblePluginsException extends InvalidTestException {
 
@@ -22,6 +20,6 @@ public class IncompatiblePluginsException extends InvalidTestException {
 		}
 		
 		List<Class<?>> list = Arrays.asList(classes);
-		return Join.join(", ", list.subList(0, list.size()-1)) + (s > 2 ? "," : "") + " and " + list.get(list.size()-1);
+		return Joiner.on(", ").join(list.subList(0, list.size()-1)) + (s > 2 ? "," : "") + " and " + list.get(list.size()-1);
 	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -73,9 +73,9 @@
 			</dependency>
 
 			<dependency>
-				<groupId>com.google.code.google-collections</groupId>
-				<artifactId>google-collect</artifactId>
-				<version>snapshot-20071022</version>
+				<groupId>com.google.collections</groupId>
+				<artifactId>google-collections</artifactId>
+				<version>1.0</version>
 			</dependency>
 
 			<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -73,9 +73,9 @@
 			</dependency>
 
 			<dependency>
-				<groupId>com.google.collections</groupId>
-				<artifactId>google-collections</artifactId>
-				<version>1.0</version>
+				<groupId>com.google.guava</groupId>
+				<artifactId>guava</artifactId>
+				<version>10.0-rc1</version>
 			</dependency>
 
 			<dependency>
@@ -124,6 +124,17 @@
 			</dependency>			
 		</dependencies>
 	</dependencyManagement>
+        
+        <distributionManagement>
+            <repository>
+		<id>main-repo</id>
+		<url>https://github.com/wcmatthysen/atunit/raw/master/releases</url>
+            </repository>
+            <snapshotRepository>
+		<id>snapshot-repo</id>
+		<url>https://github.com/wcmatthysen/atunit/raw/master/snapshots</url>
+            </snapshotRepository>
+        </distributionManagement>
 
 	<build>
 		<plugins>


### PR DESCRIPTION
Hi there,

This is the latest cleaner patch without all the indentation changes.

Commit:
-- Updated the pom so that atunit depends on a more recent release of
google collections (instead of the old snapshot). A couple of files
changes as a result of this due to the change in google-collections
API.
